### PR TITLE
优化 ConcurrentLruCache 的 computeIfAbsent 方法，避免多次调用 generator

### DIFF
--- a/core/src/main/java/com/alibaba/druid/util/ConcurrentLruCache.java
+++ b/core/src/main/java/com/alibaba/druid/util/ConcurrentLruCache.java
@@ -91,7 +91,6 @@ public final class ConcurrentLruCache<K, V> {
         this.cache.forEach((k, kvNode) -> action.accept(k, kvNode.getValue()));
     }
 
-
     private void processRead(Node<K, V> node) {
         boolean drainRequested = this.readOperations.recordRead(node);
         final DrainStatus status = this.drainStatus.get();

--- a/core/src/test/java/com/alibaba/druid/util/ConcurrentLruCacheTest.java
+++ b/core/src/test/java/com/alibaba/druid/util/ConcurrentLruCacheTest.java
@@ -3,6 +3,16 @@ package com.alibaba.druid.util;
 import junit.framework.TestCase;
 import org.junit.Assert;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
 /**
  * @author shenjianeng [ishenjianeng@qq.com]
  */
@@ -40,5 +50,39 @@ public class ConcurrentLruCacheTest extends TestCase {
         cache.clear();
         Assert.assertEquals(0, cache.size());
 
+    }
+
+    public void testComputeIfAbsent() {
+        ConcurrentLruCache<String, String> cache = new ConcurrentLruCache<>(4);
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch countDownLatch = new CountDownLatch(9);
+        List<Future<String>> futures = new ArrayList<>(20);
+        for (int i = 0; i < 20; i++) {
+            Future<String> feature =
+                    executorService.submit(() -> {
+                        try {
+                            countDownLatch.await();
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        return cache.computeIfAbsent("key", key -> UUID.randomUUID().toString());
+
+                    });
+            countDownLatch.countDown();
+            futures.add(feature);
+        }
+
+        Set<String> set = futures.stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toSet());
+
+        executorService.shutdown();
+        Assert.assertEquals(1, set.size());
     }
 }


### PR DESCRIPTION
pr_rerun QDinsight:ConcurrentLruCache to master