### PR TITLE
Fix table alias reset to empty for join queries enclosed in parentheses

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleSelectParser.java
@@ -892,8 +892,12 @@ public class OracleSelectParser extends SQLSelectParser {
 
             SQLTableSource right;
             right = parseTableSourcePrimary();
-            String tableAlias = tableAlias();
-            right.setAlias(tableAlias);
+            // Alias is already set for "... JOIN (tbl1 alias1) ON ..." syntax, 
+            // so skip setting alias
+            if (right.getAlias() == null) {
+                String tableAlias = tableAlias();
+                right.setAlias(tableAlias);
+            }
             join.setRight(right);
 
             if (lexer.token() == Token.ON) {

--- a/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleSelectParser.java
+++ b/core/src/main/java/com/alibaba/druid/sql/dialect/oracle/parser/OracleSelectParser.java
@@ -892,7 +892,7 @@ public class OracleSelectParser extends SQLSelectParser {
 
             SQLTableSource right;
             right = parseTableSourcePrimary();
-            // Alias is already set for "... JOIN (tbl1 alias1) ON ..." syntax, 
+            // Alias is already set for "... JOIN (tbl1 alias1) ON ..." syntax,
             // so skip setting alias
             if (right.getAlias() == null) {
                 String tableAlias = tableAlias();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest71.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest71.java
@@ -101,10 +101,10 @@ public class OracleSelectTest71 extends OracleTest {
                      "    B.NAME,\n" +
                      "    C.TYPE\n" +
                      "FROM\n" +
-                     "    TBL_NAME1 A\n" +
-                     "    LEFT JOIN (TBL_NAME2 B)\n" +
+                     "    tbl_name1 A\n" +
+                     "    LEFT JOIN (tbl_name2 B)\n" +
                      "    ON A.ID = B.ID\n" +
-                     "    LEFT JOIN (TBL_NAME3 C)\n" +
+                     "    LEFT JOIN (tbl_name3 C)\n" +
                      "    ON A.ID = C.ID\n" +
                      "    AND A.NAME = B.NAME";
 

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest71.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest71.java
@@ -96,15 +96,17 @@ public class OracleSelectTest71 extends OracleTest {
     }
 
     public void testSelectWithJoin_UnderParen() {
-        String sql = "SELECT\n" +
-                     "\tA.ID, B.NAME, C.TYPE\n" +
-                     "\tFROM\n" +
-                     "\ttbl_name1 A\n" +
-                     "\tLEFT JOIN (tbl_name2 B)\n" +
-                     "\tON A.ID = B.ID\n" +
-                     "\tLEFT JOIN (tbl_name3 C)\n" +
-                     "\tON A.ID = C.ID\n" +
-                     "\tAND A.NAME = B.NAME";
+        String sql = "SELECT /* NUSQL.TEST */\n" +
+                     "    A.ID,\n" +
+                     "    B.NAME,\n" +
+                     "    C.TYPE\n" +
+                     "FROM\n" +
+                     "    TBL_NAME1 A\n" +
+                     "    LEFT JOIN (TBL_NAME2 B)\n" +
+                     "    ON A.ID = B.ID\n" +
+                     "    LEFT JOIN (TBL_NAME3 C)\n" +
+                     "    ON A.ID = C.ID\n" +
+                     "    AND A.NAME = B.NAME";
 
         OracleStatementParser parser = new OracleStatementParser(sql);
         List<SQLStatement> statementList = parser.parseStatementList();

--- a/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest71.java
+++ b/core/src/test/java/com/alibaba/druid/bvt/sql/oracle/select/OracleSelectTest71.java
@@ -94,4 +94,29 @@ public class OracleSelectTest71 extends OracleTest {
 
         // Assert.assertTrue(visitor.getOrderByColumns().contains(new TableStat.Column("employees", "last_name")));
     }
+
+    public void testSelectWithJoin_UnderParen() {
+        String sql = "SELECT\n" +
+                     "\tA.ID, B.NAME, C.TYPE\n" +
+                     "\tFROM\n" +
+                     "\ttbl_name1 A\n" +
+                     "\tLEFT JOIN (tbl_name2 B)\n" +
+                     "\tON A.ID = B.ID\n" +
+                     "\tLEFT JOIN (tbl_name3 C)\n" +
+                     "\tON A.ID = C.ID\n" +
+                     "\tAND A.NAME = B.NAME";
+
+        OracleStatementParser parser = new OracleStatementParser(sql);
+        List<SQLStatement> statementList = parser.parseStatementList();
+        SQLStatement statement = statementList.get(0);
+        print(statementList);
+
+        Assert.assertEquals(1, statementList.size());
+
+        OracleSchemaStatVisitor visitor = new OracleSchemaStatVisitor();
+        statement.accept(visitor);
+
+        Assert.assertEquals(3, visitor.getTables().size());
+        Assert.assertEquals(6, visitor.getColumns().size());
+    }
 }


### PR DESCRIPTION
pr_rerun QDinsight:fix-table-alias-reset-empty-for-join-query to master